### PR TITLE
Investigate Codex web helper PoC

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -43,11 +43,31 @@ Codex session files.
 Do not attach Codex session JSONL files to bug reports or release artifacts
 unless they have been sanitized.
 
+## Codex Web Helper PoC
+
+The Codex web helper is an investigation-only proof of concept on the
+`feature/7-codex-web-helper-poc` branch. It is not a Codex usage source yet.
+
+- `codex-web-helper.ps1 login` opens Edge or Chrome with a dedicated local
+  browser profile at
+  `%LOCALAPPDATA%\trafficmonitor-claude-usage-plugin\codex-browser-profile`.
+- That profile can store ChatGPT/OpenAI browser cookies if the user signs in.
+- The current PoC writes only a local status file at
+  `%LOCALAPPDATA%\trafficmonitor-claude-usage-plugin\codex-web-helper-status.json`.
+- The current PoC does not read cookies, decrypt browser storage, call
+  authenticated OpenAI endpoints, or write Codex usage snapshots.
+
+Do not share the Codex helper browser profile or status JSON unless you have
+reviewed them first. To remove the local Codex helper PoC data, close the
+helper browser window and run `codex-web-helper.ps1 reset`.
+
 ## Network Behavior
 
 - The Claude helper makes network requests to `https://claude.ai` when fetching
   Claude usage data.
 - The Codex reader is local-file based and does not make network requests.
+- The Codex web helper PoC launches a browser pointed at `https://chatgpt.com`;
+  the helper process itself does not make authenticated OpenAI requests yet.
 - TrafficMonitor itself, Windows, Edge, Chrome, Claude, Codex, and related
   services may have their own network behavior outside this plugin.
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -45,8 +45,9 @@ unless they have been sanitized.
 
 ## Codex Web Helper PoC
 
-The Codex web helper is an investigation-only proof of concept on the
-`feature/7-codex-web-helper-poc` branch. It is not a Codex usage source yet.
+The Codex web helper is an investigation-only proof of concept unless it is
+explicitly promoted in a future release. It is not a Codex usage source yet and
+is not included in release packages.
 
 - `codex-web-helper.ps1 login` opens Edge or Chrome with a dedicated local
   browser profile at

--- a/docs/build.md
+++ b/docs/build.md
@@ -28,9 +28,11 @@ MSBuild.exe .\ClaudeUsagePlugin.sln /t:ClaudeUsagePlugin /p:Configuration=Releas
 - `build\x64\Release\plugins\ClaudeUsagePlugin.dll`
 - `build\x64\Release\plugins\ClaudeUsagePlugin\claude-web-helper.ps1`
 - `build\x64\Release\plugins\ClaudeUsagePlugin\helper\claude-web-helper\...`
+- `build\x64\Release\plugins\ClaudeUsagePlugin\codex-web-helper.ps1`
 - `build\Release\plugins\ClaudeUsagePlugin.dll`
 - `build\Release\plugins\ClaudeUsagePlugin\claude-web-helper.ps1`
 - `build\Release\plugins\ClaudeUsagePlugin\helper\claude-web-helper\...`
+- `build\Release\plugins\ClaudeUsagePlugin\codex-web-helper.ps1`
 
 The project file also contains `ARM64EC` configurations, but the published release assets are currently only `x64` and `x86`.
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -28,11 +28,9 @@ MSBuild.exe .\ClaudeUsagePlugin.sln /t:ClaudeUsagePlugin /p:Configuration=Releas
 - `build\x64\Release\plugins\ClaudeUsagePlugin.dll`
 - `build\x64\Release\plugins\ClaudeUsagePlugin\claude-web-helper.ps1`
 - `build\x64\Release\plugins\ClaudeUsagePlugin\helper\claude-web-helper\...`
-- `build\x64\Release\plugins\ClaudeUsagePlugin\codex-web-helper.ps1`
 - `build\Release\plugins\ClaudeUsagePlugin.dll`
 - `build\Release\plugins\ClaudeUsagePlugin\claude-web-helper.ps1`
 - `build\Release\plugins\ClaudeUsagePlugin\helper\claude-web-helper\...`
-- `build\Release\plugins\ClaudeUsagePlugin\codex-web-helper.ps1`
 
 The project file also contains `ARM64EC` configurations, but the published release assets are currently only `x64` and `x86`.
 

--- a/docs/codex-web-helper-investigation.md
+++ b/docs/codex-web-helper-investigation.md
@@ -1,0 +1,69 @@
+# Codex Web Helper Investigation
+
+Issue: https://github.com/bemaru/trafficmonitor-ai-usage-plugin/issues/7
+
+## Current State
+
+Codex usage limits are currently read from local Codex session JSONL files:
+
+- `%USERPROFILE%\.codex\sessions\**\*.jsonl`
+- `%CODEX_HOME%\sessions\**\*.jsonl` when Windows `CODEX_HOME` is set
+
+This keeps the plugin local-file based and avoids handling OpenAI credentials.
+The tradeoff is that the plugin only sees Codex homes that are readable from the
+Windows TrafficMonitor process and only updates after Codex writes a fresh
+rate-limit payload.
+
+## Candidate Web Helper Model
+
+The Claude helper is not an official public API integration. It uses a dedicated
+local browser profile, lets the user sign in directly, reads cookies from that
+profile, calls Claude's web usage endpoint, and writes a local JSON snapshot.
+
+A Codex web helper would need to follow the same boundary:
+
+1. Open Edge or Chrome with a dedicated local helper profile.
+2. Let the user sign in to the OpenAI-owned Codex web surface directly.
+3. Read cookies only from that dedicated helper profile.
+4. Fetch the Codex usage-limit JSON payload used by the web UI.
+5. Write a local snapshot for the TrafficMonitor plugin.
+
+## Security Boundaries
+
+The helper must not:
+
+- read the user's normal browser profile
+- reuse Codex CLI OAuth credentials
+- reuse stored OpenAI API keys
+- ask the user to paste credentials or API keys
+- upload usage data, cookies, session JSONL, or helper snapshots
+
+The helper may:
+
+- create a dedicated browser profile under `%LOCALAPPDATA%`
+- read cookies from that dedicated profile after the user signs in there
+- make cookie-authenticated requests only to OpenAI-owned web origins required
+  for the Codex web UI
+- write local status and usage snapshot files under `%LOCALAPPDATA%`
+
+## Questions To Resolve
+
+- Which origin owns the relevant Codex usage UI: `chatgpt.com`, an OpenAI
+  subdomain, or another OpenAI-owned surface?
+- Is the usage-limit data available as JSON without scraping HTML or DOM state?
+- Does the payload include both 5h and weekly usage, percentage semantics, and
+  reset timestamps?
+- How is workspace or organization selection represented?
+- What failure states map cleanly to user-facing status text?
+
+## Implementation Gate
+
+Do not replace the current session JSONL source until the Codex web payload is
+confirmed stable enough for a helper. The likely order is:
+
+1. Add multi-home JSONL support for Windows/WSL setups.
+2. Build a Codex web helper proof of concept on this branch.
+3. Decide whether the helper should be an optional fallback source.
+
+Until the web payload is confirmed, this branch should not ship a user-facing
+Codex helper in a release package.

--- a/docs/codex-web-helper-investigation.md
+++ b/docs/codex-web-helper-investigation.md
@@ -88,6 +88,33 @@ That first PoC can verify:
 Only after that manual confirmation should the branch add cookie reading or
 authenticated requests.
 
+## PoC Commands
+
+The current PoC adds only browser-profile management:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\codex-web-helper.ps1 status
+```
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\codex-web-helper.ps1 login
+```
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\codex-web-helper.ps1 reset
+```
+
+Files used by the PoC:
+
+- Dedicated browser profile:
+  `%LOCALAPPDATA%\trafficmonitor-claude-usage-plugin\codex-browser-profile`
+- Helper status:
+  `%LOCALAPPDATA%\trafficmonitor-claude-usage-plugin\codex-web-helper-status.json`
+
+The `login` command opens `https://chatgpt.com/codex` in the dedicated profile.
+It does not read cookies, inspect browser storage, call authenticated OpenAI
+endpoints, or write a usage snapshot.
+
 ## Implementation Gate
 
 Do not replace the current session JSONL source until the Codex web payload is

--- a/docs/codex-web-helper-investigation.md
+++ b/docs/codex-web-helper-investigation.md
@@ -56,6 +56,38 @@ The helper may:
 - How is workspace or organization selection represented?
 - What failure states map cleanly to user-facing status text?
 
+## Initial Findings
+
+Checked on 2026-05-06.
+
+- OpenAI Help links "Codex web" to `chatgpt.com` and notes that it requires
+  connecting ChatGPT to GitHub:
+  <https://help.openai.com/en/articles/11369540-using-codex-with-your-chatgpt-plan>
+- The same Help page says Codex usage from web or delegated cloud work is
+  available in the Compliance API, while local environment usage is not.
+- Unauthenticated `https://chatgpt.com/codex` requests return a Cloudflare
+  challenge response, so a plain Node `fetch` discovery flow is not enough.
+  A real Chromium helper profile would be needed for any browser-cookie PoC.
+- Local Codex session JSONL continues to expose `rate_limits` payloads for the
+  current local session. This remains the safer shipping source until the web
+  payload shape is verified from a dedicated helper profile.
+
+## Next Safe PoC Step
+
+The next implementation step should only add a login/open helper command for a
+dedicated Codex helper browser profile, similar to the Claude helper. It should
+not read cookies or make authenticated web requests yet.
+
+That first PoC can verify:
+
+- whether `https://chatgpt.com/codex` loads successfully in the dedicated
+  profile after user login
+- which origin and route the browser lands on
+- whether DevTools/manual inspection shows a JSON usage payload worth automating
+
+Only after that manual confirmation should the branch add cookie reading or
+authenticated requests.
+
 ## Implementation Gate
 
 Do not replace the current session JSONL source until the Codex web payload is

--- a/docs/codex-web-helper-investigation.md
+++ b/docs/codex-web-helper-investigation.md
@@ -119,6 +119,25 @@ This PoC script is intentionally not copied into release build output yet. It
 should stay outside release packages until the web payload is manually verified
 and the helper is accepted as a supported source or fallback.
 
+## Manual Verification Checklist
+
+After running `login`, verify the web payload manually in the helper browser
+profile:
+
+1. Sign in to ChatGPT/OpenAI in the helper browser window.
+2. Confirm that `https://chatgpt.com/codex` loads a Codex page instead of a
+   login page, Cloudflare challenge, or generic ChatGPT page.
+3. Open DevTools Network tab and refresh the Codex page.
+4. Filter for JSON or fetch/XHR requests that include usage, quota, limit,
+   rate-limit, allowance, plan, workspace, organization, or account data.
+5. Confirm whether any response contains 5-hour and weekly usage percentages
+   plus reset timestamps.
+6. Do not copy cookies, authorization headers, session tokens, prompts, or
+   private repository data into issues, PRs, logs, or screenshots.
+
+Record only sanitized endpoint names, response field names, and whether the
+payload is stable enough to automate.
+
 ## Implementation Gate
 
 Do not replace the current session JSONL source until the Codex web payload is

--- a/docs/codex-web-helper-investigation.md
+++ b/docs/codex-web-helper-investigation.md
@@ -141,11 +141,14 @@ payload is stable enough to automate.
 ## Implementation Gate
 
 Do not replace the current session JSONL source until the Codex web payload is
-confirmed stable enough for a helper. The likely order is:
+confirmed stable enough for a helper. The remaining order is:
 
-1. Add multi-home JSONL support for Windows/WSL setups.
-2. Build a Codex web helper proof of concept on this branch.
-3. Decide whether the helper should be an optional fallback source.
+1. Run the manual DevTools verification from the dedicated helper profile.
+2. Record only sanitized endpoint names, response field names, payload shape,
+   workspace or organization selection behavior, and error-state behavior.
+3. Decide whether the helper should become an optional fallback source.
+4. If the web payload is not stable enough, keep session JSONL as the only
+   source and revisit multi-home JSONL support for Windows/WSL setups.
 
 Until the web payload is confirmed, this branch should not ship a user-facing
 Codex helper in a release package.

--- a/docs/codex-web-helper-investigation.md
+++ b/docs/codex-web-helper-investigation.md
@@ -115,6 +115,10 @@ The `login` command opens `https://chatgpt.com/codex` in the dedicated profile.
 It does not read cookies, inspect browser storage, call authenticated OpenAI
 endpoints, or write a usage snapshot.
 
+This PoC script is intentionally not copied into release build output yet. It
+should stay outside release packages until the web payload is manually verified
+and the helper is accepted as a supported source or fallback.
+
 ## Implementation Gate
 
 Do not replace the current session JSONL source until the Codex web payload is

--- a/scripts/codex-web-helper.ps1
+++ b/scripts/codex-web-helper.ps1
@@ -1,0 +1,162 @@
+param(
+    [ValidateSet('login', 'status', 'reset')]
+    [string]$Mode = 'status'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$baseDir = if ($env:LOCALAPPDATA) {
+    Join-Path $env:LOCALAPPDATA 'trafficmonitor-claude-usage-plugin'
+} else {
+    Join-Path $env:USERPROFILE '.cache\trafficmonitor-claude-usage-plugin'
+}
+$profileDir = Join-Path $baseDir 'codex-browser-profile'
+$statusPath = Join-Path $baseDir 'codex-web-helper-status.json'
+$targetUrl = if ($env:CODEX_WEB_HELPER_URL) { $env:CODEX_WEB_HELPER_URL } else { 'https://chatgpt.com/codex' }
+
+function Get-RelativeAgeText {
+    param([object]$Timestamp)
+
+    if (-not $Timestamp) {
+        return 'unknown'
+    }
+
+    $timestampValue = [datetime]$Timestamp
+    $span = [datetime]::UtcNow - $timestampValue.ToUniversalTime()
+    if ($span.TotalSeconds -lt 0) {
+        return 'just now'
+    }
+
+    if ($span.TotalMinutes -lt 1) {
+        return ('{0:n0}s ago' -f $span.TotalSeconds)
+    }
+
+    if ($span.TotalHours -lt 1) {
+        return ('{0:n0}m ago' -f $span.TotalMinutes)
+    }
+
+    return ('{0:n1}h ago' -f $span.TotalHours)
+}
+
+function Format-FileStatus {
+    param([string]$Path)
+
+    if (-not (Test-Path $Path)) {
+        return "$Path [missing]"
+    }
+
+    $item = Get-Item $Path
+    return "$Path [$([int64]$item.Length) bytes, $($item.LastWriteTime.ToString('yyyy-MM-dd HH:mm:ss')), $(Get-RelativeAgeText $item.LastWriteTime)]"
+}
+
+function Show-Status {
+    Write-Host "Profile dir: $profileDir"
+    Write-Host (Format-FileStatus $statusPath)
+
+    if (Test-Path $statusPath) {
+        try {
+            $status = Get-Content $statusPath -Raw | ConvertFrom-Json
+            Write-Host "Status: $($status.state)"
+            Write-Host "Updated: $($status.updated_at)"
+            if ($status.target_url) {
+                Write-Host "Target URL: $($status.target_url)"
+            }
+            if ($status.error) {
+                Write-Host "Error: $($status.error)"
+            }
+        } catch {
+            Write-Host "Status: unreadable ($($_.Exception.Message))"
+        }
+    }
+}
+
+function Write-Status {
+    param(
+        [string]$State,
+        [hashtable]$Details = @{}
+    )
+
+    if (-not (Test-Path $baseDir)) {
+        New-Item -ItemType Directory -Path $baseDir -Force | Out-Null
+    }
+
+    $payload = [ordered]@{
+        state = $State
+        updated_at = [datetime]::UtcNow.ToString('o')
+    }
+
+    foreach ($key in $Details.Keys) {
+        $payload[$key] = $Details[$key]
+    }
+
+    $tempPath = "$statusPath.tmp"
+    $payload | ConvertTo-Json -Depth 8 | Set-Content -Path $tempPath -Encoding UTF8
+    Move-Item -Path $tempPath -Destination $statusPath -Force
+}
+
+function Get-BrowserPath {
+    if ($env:CODEX_WEB_HELPER_BROWSER -and (Test-Path $env:CODEX_WEB_HELPER_BROWSER)) {
+        return $env:CODEX_WEB_HELPER_BROWSER
+    }
+
+    $candidates = @(
+        'C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe',
+        'C:\Program Files\Microsoft\Edge\Application\msedge.exe',
+        'C:\Program Files\Google\Chrome\Application\chrome.exe',
+        'C:\Program Files (x86)\Google\Chrome\Application\chrome.exe'
+    )
+
+    return $candidates |
+        Where-Object { Test-Path $_ } |
+        Select-Object -First 1
+}
+
+function Open-LoginBrowser {
+    if (-not (Test-Path $profileDir)) {
+        New-Item -ItemType Directory -Path $profileDir -Force | Out-Null
+    }
+
+    $browserPath = Get-BrowserPath
+    if (-not $browserPath) {
+        throw 'Browser executable not found. Set CODEX_WEB_HELPER_BROWSER.'
+    }
+
+    $arguments = @(
+        "--user-data-dir=$profileDir",
+        '--new-window',
+        $targetUrl
+    )
+
+    $process = Start-Process -FilePath $browserPath -ArgumentList $arguments -PassThru
+    Write-Status 'login_browser_opened' @{
+        profile_dir = $profileDir
+        target_url = $targetUrl
+        browser_path = $browserPath
+        browser_pid = $process.Id
+    }
+
+    Write-Host 'Opened a normal browser window for Codex web login.'
+    Write-Host 'Complete the login there. This PoC does not read cookies or fetch usage yet.'
+}
+
+switch ($Mode) {
+    'login' {
+        Open-LoginBrowser
+        Show-Status
+        exit 0
+    }
+    'reset' {
+        if (Test-Path $profileDir) {
+            Remove-Item -Path $profileDir -Recurse -Force
+        }
+        Write-Status 'reset' @{
+            profile_dir = $profileDir
+        }
+        Show-Status
+        exit 0
+    }
+    'status' {
+        Show-Status
+        exit 0
+    }
+}

--- a/scripts/codex-web-helper.ps1
+++ b/scripts/codex-web-helper.ps1
@@ -12,7 +12,7 @@ $baseDir = if ($env:LOCALAPPDATA) {
 }
 $profileDir = Join-Path $baseDir 'codex-browser-profile'
 $statusPath = Join-Path $baseDir 'codex-web-helper-status.json'
-$targetUrl = if ($env:CODEX_WEB_HELPER_URL) { $env:CODEX_WEB_HELPER_URL } else { 'https://chatgpt.com/codex' }
+$targetUrl = 'https://chatgpt.com/codex'
 
 function Get-RelativeAgeText {
     param([object]$Timestamp)
@@ -122,7 +122,7 @@ function Open-LoginBrowser {
     }
 
     $arguments = @(
-        "--user-data-dir=$profileDir",
+        "--user-data-dir=`"$profileDir`"",
         '--new-window',
         $targetUrl
     )

--- a/src/ClaudeUsagePlugin/ClaudeUsagePlugin.vcxproj
+++ b/src/ClaudeUsagePlugin/ClaudeUsagePlugin.vcxproj
@@ -513,13 +513,18 @@
     <ClaudeHelperAsset Include="$(RepoRoot)helper\claude-web-helper\package-lock.json">
       <Destination>$(OutDir)ClaudeUsagePlugin\helper\claude-web-helper\package-lock.json</Destination>
     </ClaudeHelperAsset>
+    <CodexHelperAsset Include="$(RepoRoot)scripts\codex-web-helper.ps1">
+      <Destination>$(OutDir)ClaudeUsagePlugin\codex-web-helper.ps1</Destination>
+    </CodexHelperAsset>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="CopyClaudeHelperAssets" AfterTargets="Build">
     <Delete Files="$(OutDir)claude-web-helper.ps1" />
+    <Delete Files="$(OutDir)codex-web-helper.ps1" />
     <RemoveDir Directories="$(OutDir)helper" />
     <MakeDir Directories="$(OutDir)ClaudeUsagePlugin\helper\claude-web-helper" />
     <Copy SourceFiles="@(ClaudeHelperAsset)" DestinationFiles="@(ClaudeHelperAsset->'%(Destination)')" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(CodexHelperAsset)" DestinationFiles="@(CodexHelperAsset->'%(Destination)')" SkipUnchangedFiles="true" />
   </Target>
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/src/ClaudeUsagePlugin/ClaudeUsagePlugin.vcxproj
+++ b/src/ClaudeUsagePlugin/ClaudeUsagePlugin.vcxproj
@@ -513,18 +513,14 @@
     <ClaudeHelperAsset Include="$(RepoRoot)helper\claude-web-helper\package-lock.json">
       <Destination>$(OutDir)ClaudeUsagePlugin\helper\claude-web-helper\package-lock.json</Destination>
     </ClaudeHelperAsset>
-    <CodexHelperAsset Include="$(RepoRoot)scripts\codex-web-helper.ps1">
-      <Destination>$(OutDir)ClaudeUsagePlugin\codex-web-helper.ps1</Destination>
-    </CodexHelperAsset>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Target Name="CopyClaudeHelperAssets" AfterTargets="Build">
     <Delete Files="$(OutDir)claude-web-helper.ps1" />
-    <Delete Files="$(OutDir)codex-web-helper.ps1" />
+    <Delete Files="$(OutDir)ClaudeUsagePlugin\codex-web-helper.ps1" />
     <RemoveDir Directories="$(OutDir)helper" />
     <MakeDir Directories="$(OutDir)ClaudeUsagePlugin\helper\claude-web-helper" />
     <Copy SourceFiles="@(ClaudeHelperAsset)" DestinationFiles="@(ClaudeHelperAsset->'%(Destination)')" SkipUnchangedFiles="true" />
-    <Copy SourceFiles="@(CodexHelperAsset)" DestinationFiles="@(CodexHelperAsset->'%(Destination)')" SkipUnchangedFiles="true" />
   </Target>
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>


### PR DESCRIPTION
## Summary

- Documents the security boundary for a possible Codex web helper source.
- Records initial discovery that Codex web is under chatgpt.com and unauthenticated requests hit Cloudflare challenge.
- Adds a minimal scripts/codex-web-helper.ps1 PoC with status, login, and reset only.
- Keeps the PoC script out of release build output and release packages until the web payload is manually verified.
- Adds a manual DevTools checklist for verifying whether a sanitized Codex usage payload exists.

## Security boundary

The PoC does not read cookies, decrypt browser storage, call authenticated OpenAI endpoints, or write Codex usage snapshots. login only opens https://chatgpt.com/codex in a dedicated local browser profile.

## Verification

- PowerShell source script status passed.
- PowerShell source script reset passed.
- PowerShell source script login opened the dedicated profile and wrote login_browser_opened status.
- MSBuild Release x64 passed locally.
- Verified build/x64/Release/plugins/ClaudeUsagePlugin/codex-web-helper.ps1 is not present after build.
- Subagent security/privacy review found no P0/P1/P2 blockers for draft PoC state.
- Subagent packaging/docs review found no blockers after keeping the PoC outside release assets.

## Remaining manual check

A user must sign in inside the helper browser profile and inspect DevTools Network manually. Only sanitized endpoint names and response field names should be recorded. Do not copy cookies, authorization headers, session tokens, prompts, or private repository data.

Future work questions from #7:

- Does a JSON payload expose 5-hour and weekly usage percentages plus reset timestamps?
- How are workspace or organization selection represented?
- What error states are needed for login expired, access denied, Cloudflare/challenge, and payload-shape changes?
- Where should sanitized endpoint and response-field findings be recorded before any automation is added?

## Related

Closes no issue yet. Continues #7.